### PR TITLE
Create proper .so symlinks for libkonkretmof

### DIFF
--- a/src/mof/CMakeLists.txt
+++ b/src/mof/CMakeLists.txt
@@ -38,7 +38,8 @@ set(konkretmof_SRCS
 
 add_library(konkretmof SHARED ${konkretmof_SRCS})
 
-set_target_properties(konkretmof PROPERTIES SOVERSION 0.0.1)
+set_target_properties(konkretmof PROPERTIES VERSION 0.0.1)
+set_target_properties(konkretmof PROPERTIES SOVERSION 0)
 
 install(TARGETS konkretmof DESTINATION lib${LIB_SUFFIX})
 


### PR DESCRIPTION
Building libkonkretmof results in libkonkretmof.so -> libkonkretmof.so.0.0.1

With this fix, the symlink is corrected to
libkonkretmof.so -> libkonkretmof.so.0
libkonkretmof.so.0 -> libkonkretmof.so.0.0.1
