### PR TITLE
mof: Include sys/types.h for u_intXX definitions

### DIFF
--- a/src/mof/MOF_Config.h
+++ b/src/mof/MOF_Config.h
@@ -34,6 +34,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <sys/types.h>
 #endif
 
 #if defined(__GNUC__) && (__GNUC__ >= 4)


### PR DESCRIPTION
Fixes build with musl

Signed-off-by: Khem Raj <raj.khem@gmail.com>